### PR TITLE
Use https for cdn to avoid cross site scripting errors

### DIFF
--- a/lib/middleman-gibberish.rb
+++ b/lib/middleman-gibberish.rb
@@ -124,7 +124,7 @@ module ::Middleman
   #
     def script_for(glob, path, encrypted)
       libs = %w( jquery.js jquery.cookie.js gibberish.js )
-      cdn = 'http://ahoward.github.io/middleman-gibberish/assets/'
+      cdn = 'https://ahoward.github.io/middleman-gibberish/assets/'
 
       scripts =
         libs.map do |lib|


### PR DESCRIPTION
This updates the cdn address to use https instead of http
to avoid cross site scripting errors on sites hosted using
ssl.